### PR TITLE
This is the schema, and the cleaned datasets which fit into them.

### DIFF
--- a/Completedschema.sql
+++ b/Completedschema.sql
@@ -1,0 +1,28 @@
+--Schema for the Athletes table (final_athlete_clean_data)
+
+CREATE TABLE athletes(
+ 	ID INT,
+	Name VARCHAR,
+	Sex VARCHAR,
+	Age INT,
+	Height DECIMAL,
+	Weight DECIMAL,
+	Team VARCHAR,
+	NOC VARCHAR,
+	Games VARCHAR,
+	Sport VARCHAR,
+	Event VARCHAR,
+	Medal VARCHAR
+);
+
+
+
+--schema for games table (Olypic_games_clean)
+
+CREATE TABLE Games(
+	ID INT,
+	Games VARCHAR,
+	Year INT,
+	Season VARCHAR, 
+	City VARCHAR
+)

--- a/olypic_games_clean.csv
+++ b/olypic_games_clean.csv
@@ -1,0 +1,53 @@
+ID,Games,Year,Season,City
+1,1896 Summer,1896,Summer,Athina
+2,1900 Summer,1900,Summer,Paris
+3,1904 Summer,1904,Summer,St. Louis
+4,1906 Summer,1906,Summer,Athina
+5,1908 Summer,1908,Summer,London
+6,1912 Summer,1912,Summer,Stockholm
+7,1920 Summer,1920,Summer,Antwerpen
+8,1924 Winter,1924,Winter,Chamonix
+9,1924 Summer,1924,Summer,Paris
+10,1928 Summer,1928,Summer,Amsterdam
+11,1928 Winter,1928,Winter,Sankt Moritz
+12,1932 Winter,1932,Winter,Lake Placid
+13,1932 Summer,1932,Summer,Los Angeles
+14,1936 Winter,1936,Winter,Garmisch-Partenkirchen
+15,1936 Summer,1936,Summer,Berlin
+16,1948 Summer,1948,Summer,London
+17,1948 Winter,1948,Winter,Sankt Moritz
+18,1952 Winter,1952,Winter,Oslo
+19,1952 Summer,1952,Summer,Helsinki
+20,1956 Winter,1956,Winter,Cortina d'Ampezzo
+21,1956 Summer,1956,Summer,Stockholm
+22,1956 Summer,1956,Summer,Melbourne
+23,1960 Winter,1960,Winter,Squaw Valley
+24,1960 Summer,1960,Summer,Roma
+25,1964 Winter,1964,Winter,Innsbruck
+26,1964 Summer,1964,Summer,Tokyo
+27,1968 Winter,1968,Winter,Grenoble
+28,1968 Summer,1968,Summer,Mexico City
+29,1972 Summer,1972,Summer,Munich
+30,1972 Winter,1972,Winter,Sapporo
+31,1976 Summer,1976,Summer,Montreal
+32,1976 Winter,1976,Winter,Innsbruck
+33,1980 Summer,1980,Summer,Moskva
+34,1980 Winter,1980,Winter,Lake Placid
+35,1984 Summer,1984,Summer,Los Angeles
+36,1984 Winter,1984,Winter,Sarajevo
+37,1988 Winter,1988,Winter,Calgary
+38,1988 Summer,1988,Summer,Seoul
+39,1992 Winter,1992,Winter,Albertville
+40,1992 Summer,1992,Summer,Barcelona
+41,1994 Winter,1994,Winter,Lillehammer
+42,1996 Summer,1996,Summer,Atlanta
+43,1998 Winter,1998,Winter,Nagano
+44,2000 Summer,2000,Summer,Sydney
+45,2002 Winter,2002,Winter,Salt Lake City
+46,2004 Summer,2004,Summer,Athina
+47,2006 Winter,2006,Winter,Torino
+48,2008 Summer,2008,Summer,Beijing
+49,2010 Winter,2010,Winter,Vancouver
+50,2012 Summer,2012,Summer,London
+51,2014 Winter,2014,Winter,Sochi
+52,2016 Summer,2016,Summer,Rio de Janeiro


### PR DESCRIPTION
This is the schema created for the two tables, along with the datasets that fit. We had to remove certain punctuation from the athlete data for postgres to be able to parse it. If any past saved file of this data is used, it will not work. Final_athlete_clean_data is for the athlete table, and olypic_games_clean is for the games table. 